### PR TITLE
Arrumando bug do conversor

### DIFF
--- a/conversor_dados.py
+++ b/conversor_dados.py
@@ -16,7 +16,6 @@ class Arrumando_entrada():
         self.vetor_dados_saida = self._arrumando_entrada()
 
     
-    #  unica funcao que é necessaria saber para usar a classe.
     def get_lista_valores(self):
         return self.vetor_dados_saida
 

--- a/conversor_dados.py
+++ b/conversor_dados.py
@@ -193,8 +193,12 @@ class Converte_vetor_string:
             if valor.teste_dezena or valor.teste_centena :
                 palavra_saida = "{}".format(valor.nome)
 
-            if valor.teste_milhar or valor.teste_milhar_dezena or valor.teste_e_milhar :
+            if valor.teste_milhar or valor.teste_milhar_dezena :
                 palavra_saida = "{} mil".format(valor.nome)
+
+            if valor.teste_e_milhar:
+                palavra_saida = "mil"
+
 
             vetor_string.append(palavra_saida)
 
@@ -274,7 +278,7 @@ class Converte_numero:
             700:"setecentos",
             800:"oitocentos",
             900:"novecentos",
-            1000:"mil"
+            1000:""
             }
         self.numero_objeto = numero
 
@@ -287,6 +291,8 @@ class Converte_numero:
     def _encontra_numero_nome(self,numero_e):
         # Aqui é numero_e é um valor inteiro
         numero = self._testa_milhar(numero_e)
+
+        # resolvendo o bug do milhar
         return self.dicionario[numero]
 
     def _testa_milhar(self,valor):

--- a/conversor_dados.py
+++ b/conversor_dados.py
@@ -158,22 +158,30 @@ class Converte_vetor_string:
             return "{0} e {1} e {2} e {3} e {4}".format(self._tratar_primeiro_mil(vetor[0]),vetor[1], vetor[2],vetor[3], vetor[4])
                   
         if(self.vetor_dados_objeto.tes_tamanho_igual_4):
+            vetor[3] = self._teste_cento(vetor[3])
             return "{0} e {1} e {2} e {3}".format(self._tratar_primeiro_mil(vetor[0]),vetor[1], vetor[2],vetor[3])
             
         if(self.vetor_dados_objeto.tes_tamanho_igual_3):
+            vetor[2] = self._teste_cento(vetor[2])
             return "{0} e {1} e {2}".format(self._tratar_primeiro_mil(vetor[0]),vetor[1], vetor[2])
             
         if(self.vetor_dados_objeto.tes_tamanho_igual_2):
+            vetor[1] = self._teste_cento(vetor[1])
             return "{0} e {1}".format(self._tratar_primeiro_mil(vetor[0]),vetor[1])
             
         if(self.vetor_dados_objeto.tes_tamanho_igual_1):
-            # tratar o caso do 100
-            # refatorar
-            if("cento" == vetor[0]):
-                return "cem"
-            else:
-                return "{}".format(vetor[0])
+            vetor[0] = self._teste_cento(vetor[0])
+            return "{}".format(vetor[0])
             
+
+    def _teste_cento(self, string):
+        
+        test_cento = string == "cento"
+        if(test_cento):
+            return "cem"
+        else:
+            return string
+
 
     def _tratar_primeiro_mil(self,string):
         if(self.vetor_dados_objeto.tes_case_mil_mil):
@@ -259,7 +267,7 @@ class Converte_numero:
             15:"quinze",
             16:"dezeseis",
             17:"dezesete",
-            18:"dezoito",
+            18:"dezoito", 
             19:"dezenove",
             20:"vinte",
             30:"trinta",

--- a/test_conversor_dados.py
+++ b/test_conversor_dados.py
@@ -204,7 +204,7 @@ def test_c_Conversor_dados_nome():
                     [2000],
                     [5000]]
 
-        bloco_teste_saida = ['um mil e cento e quarenta e dois',
+        bloco_teste_saida = ['mil e cento e quarenta e dois',
                               'vinte e nove mil e trezentos e dezenove',
                                'duzentos e vinte e dois',
                                 'dezenove',
@@ -218,7 +218,7 @@ def test_c_Conversor_dados_nome():
                                  'um',
                                  'dez',
                                  'cem',
-                                 'um mil',
+                                 'mil',
                                  'dois mil',
                                  'cinco mil']
 
@@ -251,7 +251,7 @@ def test_c_Vetor_dados_nome():
                     [2000],
                     [5000]]
 
-        bloco_teste_saida = ['um mil e cento e quarenta e dois',
+        bloco_teste_saida = ['mil e cento e quarenta e dois',
                               'vinte e nove mil e trezentos e dezenove',
                                'duzentos e vinte e dois',
                                 'dezenove',
@@ -265,7 +265,7 @@ def test_c_Vetor_dados_nome():
                                  'um',
                                  'dez',
                                  'cem',
-                                 'um mil',
+                                 'mil',
                                  'dois mil',
                                  'cinco mil']
 

--- a/test_conversor_dados.py
+++ b/test_conversor_dados.py
@@ -249,7 +249,10 @@ def test_c_Vetor_dados_nome():
                     [100],
                     [1000],
                     [2000],
-                    [5000]]
+                    [5000],
+                    [1000,100],
+                    [9000,100],
+                    [19000, 100]]
 
         bloco_teste_saida = ['mil e cento e quarenta e dois',
                               'vinte e nove mil e trezentos e dezenove',
@@ -267,7 +270,10 @@ def test_c_Vetor_dados_nome():
                                  'cem',
                                  'mil',
                                  'dois mil',
-                                 'cinco mil']
+                                 'cinco mil',
+                                 "mil e cem",
+                                 "nove mil e cem",
+                                 "dezenove mil e cem"]
 
         for count,teste in enumerate(bloco_teste):
                 recebe = Vetor_dados(teste)

--- a/test_conversor_dados.py
+++ b/test_conversor_dados.py
@@ -114,37 +114,6 @@ def test_saida_arrumada():
 # Os testes precisam de casos no qual de erro
 # Os negativos serão tratos a posteriori
 
-# comecar os testes para a classe Converte_numero
-
-        # assert saida == bloco_teste_saida[count]
-
-
-# def test_converte_numero_get_test_cases():
-
-#     bloco_teste = [ [1000, 0,40,2],
-#                     [20000,9000, 300,10,9],
-#                     [200, 20, 2],
-#                     [10,9],
-#                     [20,9],
-#                     [10000,9000, 300,20,1],
-#                     [20000,9000, 300,20,1],
-#                     [10000,9000, 300,10,9],
-#                     [1],
-#                     [20000,9000, 300,10,9],
-#                     [90000,4000,500,80,7],
-#                     [1],
-#                     [10],
-#                     [100],
-#                     [1000],
-#                     [2000],
-#                     [5000]]
-
-#     for count,teste in enumerate(bloco_teste):
-#         parser_entrada = Converte_numero(teste)
-#         saida = parser_entrada._get_cases()
-#         print(saida)
-# arrumar o teste para ver se ele extrai as caracteristicas dos numeros
-
 def test_c_Numero():
         #caso fuja o valor do dicionario quebra e.g(9999)
     bloco_teste = [ 1,

--- a/test_sistema.py
+++ b/test_sistema.py
@@ -25,7 +25,7 @@ def test_Transforma_numero_extensao():
                         "94587"]
 
 
-        bloco_teste_saida = ['um mil e cento e quarenta e dois',
+        bloco_teste_saida = ['mil e cento e quarenta e dois',
                               'vinte e nove mil e trezentos e dezenove',
                                'duzentos e vinte e dois',
                                 'dezenove',
@@ -38,13 +38,13 @@ def test_Transforma_numero_extensao():
                                  'um',
                                  'dez',
                                  'cem',
-                                 'um mil',
+                                 'mil',
                                  'dois mil',
                                  'cinco mil',
-                                 "um mil e quarenta e dois",
+                                 "mil e quarenta e dois",
                                  "zero",
                                  'menos vinte e nove mil e trezentos e dezenove',
-                                 "menos um mil e quarenta e dois",
+                                 "menos mil e quarenta e dois",
                                  "noventa e quatro mil e quinhentos e oitenta e sete"
                                  ]
 
@@ -71,7 +71,7 @@ def test_Saida_Desafio_Certi():
                         "94587"]
 
 
-        bloco_teste_saida = ['{"extenso": "um mil e cento e quarenta e dois"}',
+        bloco_teste_saida = ['{"extenso": "mil e cento e quarenta e dois"}',
                         '{"extenso": "vinte e nove mil e trezentos e dezenove"}',
                         '{"extenso": "duzentos e vinte e dois"}',
                         '{"extenso": "dezenove"}',
@@ -79,7 +79,7 @@ def test_Saida_Desafio_Certi():
                         '{"extenso": "dezenove mil e trezentos e vinte e um"}',
                         '{"extenso": "um"}',
                         '{"extenso": "noventa e quatro mil e quinhentos e oitenta e sete"}',
-                        '{"extenso": "menos um mil e quarenta e dois"}',
+                        '{"extenso": "menos mil e quarenta e dois"}',
                         '{"extenso": "noventa e quatro mil e quinhentos e oitenta e sete"}'
                                  ]
 


### PR DESCRIPTION
Foi arrumado o bug #4 . Estava ocorrendo erros de conversão quando vinha os números que continham o valor 1000 em sua composição. Sempre era adicionado a palavra "um" a frente do mil (E.g., um mil cento e quarenta e dois) agora isso não mais acontece (e.g., mil cento e quarenta e dois). Também, foi corrigido a conversão quando o numero 100 vinha por ultimo (e.g,[1000,100]).  Antes o 100 era traduzido para "cento" (e.g., um mil e cento) agora esta sendo traduzido para "cem".



