### PR TITLE
Deployment Heroku [hot-fix]

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+
+
+[packages]
+
+Flask = "*"
+
+[requires]
+
+python_version = "3.6"

--- a/servidor.py
+++ b/servidor.py
@@ -4,6 +4,7 @@ from flask import Flask
 # from flask import jsonify
 import json
 
+import os
 app = Flask(__name__)
 
 class Saida_Desafio_Certi:
@@ -23,7 +24,8 @@ def hello1(string_entrada):
 
 
 if __name__ == "__main__":
-    app.run(host= '0.0.0.0')
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host= '0.0.0.0', port=port)
 
 
 

--- a/test_conversor_dados.py
+++ b/test_conversor_dados.py
@@ -77,12 +77,7 @@ def test_regra_excecao():
         saida = parser_entrada._testando_regra_excecao()
         
         assert saida == bloco_teste_saida[count]
-#     bloco_teste_resposta = [[200, 20, 2],
-#                     [19],[20,9],
-#                     [19000, 300,20,1],
-#                     [20000,9000, 300,20,1],
-#                     [19000, 300,19]]
-    
+
 
 def test_saida_arrumada():
 


### PR DESCRIPTION
O projeto foi posto em produção nos servidores do [Heroku](https://heroku.com). Agora, pode-se acessar a resposta do servidor via o link [ converte o numero 13457](https://certi-desafio.herokuapp.com/13457)

# Obs

O servidor não estava funcionando em produção por causa da porta 5000. O Flask geralmente trabalha com essa porta, porém não sei qual é a rota dos servidores do Heroku. No fim, as conversões realizadas tornam a entrada no servidor pela porta padrão 80. O erro foi descoberto graças ao exemplo entregue pelo [site da jessica](https://jtemporal.com/deploy-flask-heroku/). Ela informa , inclusive, adicionar um arquivo chamado:- "Pipfile". Não tenho certeza se esse arquivo é realmente necessário. Talvez, o arquivo correto seja o:- "Pipfile.lock". Penso que seja esse o arquivo certo por causa do logs apresentados pelo Heroku quando ele esta montando o servidor. Mas essa questão deve ser investigada a posteriori.

# Tarefas
- [Deployment Heroku](https://github.com/jmarcolan/desafio_certi/projects/1#card-24488372)


